### PR TITLE
fix: repoint control plane probes to api.moleculesai.app (Railway)

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -23,12 +23,16 @@ sites:
     # Developer documentation at doc.moleculesai.app (Fumadocs/Next.js, deployed via Vercel)
 
   - name: Control plane API
-    url: https://molecule-cp.fly.dev/health
-    # /health returns {"service":"molecule-cp","status":"ok"}
+    url: https://api.moleculesai.app/health
+    # /health returns {"service":"molecule-cp","status":"ok"}.
+    # Repointed from molecule-cp.fly.dev → api.moleculesai.app (Railway)
+    # after the Apr 2026 infra migration; the old fly.dev host is
+    # retired and was showing the CP as "down" on every check.
 
   - name: Control plane — Legal pages
-    url: https://molecule-cp.fly.dev/legal/terms
-    # HTML page; tests markdown-renderer path + static embed still works
+    url: https://api.moleculesai.app/legal/terms
+    # HTML page; tests markdown-renderer path + static embed still works.
+    # Repointed off fly.dev (see note above).
 
   - name: Landing page
     url: https://www.moleculesai.app/


### PR DESCRIPTION
## Problem
Status page showed the Control Plane API + Legal pages at 29.94% uptime because Upptime was still probing `molecule-cp.fly.dev` — the retired Fly.io host we migrated off in the Apr 2026 Railway cutover. Every probe since that cutover has connection-refused → false 'down' alarm.

## Fix
- `Control plane API`: `https://api.moleculesai.app/health`
- `Control plane — Legal pages`: `https://api.moleculesai.app/legal/terms`

Both verified returning 200 just now.

## Test plan
- [x] `curl https://api.moleculesai.app/health` returns `{"service":"molecule-cp","status":"ok"}`
- [x] `curl https://api.moleculesai.app/legal/terms` returns 200 + HTML
- [ ] After merge: next Upptime workflow run (every 5 min) probes the new URLs, history turns green
- [ ] History/README regenerated by Upptime's summary workflow — no manual touch-up