### PR TITLE
ci: add timeout-minutes to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/graphs.yml
+++ b/.github/workflows/graphs.yml
@@ -11,6 +11,7 @@ jobs:
   release:
     name: Generate graphs
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/response-time.yml
+++ b/.github/workflows/response-time.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     name: Update response time graphs
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/static-site.yml
+++ b/.github/workflows/static-site.yml
@@ -17,6 +17,7 @@ jobs:
   release:
     name: Build and deploy status site
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -11,6 +11,7 @@ jobs:
   release:
     name: Generate README + summary
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -19,6 +19,7 @@ jobs:
   release:
     name: Check status of endpoints
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
Add explicit timeouts to prevent runaway jobs:
- uptime.yml: 5 min (fast checks)
- response-time.yml: 5 min (API calls)
- graphs.yml: 5 min (data generation)
- summary.yml: 5 min (README updates)
- static-site.yml: 10 min (build + deploy)

## Test plan
- [x] Workflows still pass syntax validation
- [ ] Verify timeouts work as expected when workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)